### PR TITLE
fix: Remove vestigial parameter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ kotlin {
 apply plugin: 'maven-publish'
 
 group = 'net.ddns.mindustry'
-version = '0.2.0'
+version = '0.2.1'
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/net/ddns/mindustry/segment/Events.kt
+++ b/src/main/kotlin/net/ddns/mindustry/segment/Events.kt
@@ -33,7 +33,7 @@ fun loadEvents() {
 //    textInputHandler.removeTextInput(event.textInputId)
 //}
 
-private fun testCallback(player: Player, args: Array<String>, child: Child) {
+private fun testCallback(player: Player, child: Child) {
     if (child !is BaseTextInput) {
         return
     }
@@ -41,7 +41,7 @@ private fun testCallback(player: Player, args: Array<String>, child: Child) {
     player.sendMessage("You typed in: ${child.text}")
 }
 
-private fun menuCallback(player: Player, args: Array<String>, child: Child) {
+private fun menuCallback(player: Player, child: Child) {
     if (child !is BaseMenu) {
         return
     }

--- a/src/main/kotlin/net/ddns/mindustry/segment/ui/Child.kt
+++ b/src/main/kotlin/net/ddns/mindustry/segment/ui/Child.kt
@@ -7,7 +7,7 @@ abstract class Child (
     open val title: String,
     open val message: String,
     open val id: Int,
-    open val callback: (player: Player, args: Array<String>, Child) -> Unit,
+    open val callback: (Player, Child) -> Unit,
     val args: Array<String> = arrayOf(),
     private val default: String = "",
     ) {

--- a/src/main/kotlin/net/ddns/mindustry/segment/ui/UIHandler.kt
+++ b/src/main/kotlin/net/ddns/mindustry/segment/ui/UIHandler.kt
@@ -14,7 +14,7 @@ abstract class UIHandler<T>
 
     fun executeCallback(id: Int, player: Player) {
         val args = children[id]!!.args
-        children[id]!!.callback(player, args, children[id]!!)
+        children[id]!!.callback(player, children[id]!!)
     }
 
 //    abstract fun executeCallback(id: Int, player: Player, text: String?)

--- a/src/main/kotlin/net/ddns/mindustry/segment/ui/menu/BaseMenu.kt
+++ b/src/main/kotlin/net/ddns/mindustry/segment/ui/menu/BaseMenu.kt
@@ -12,7 +12,7 @@ class BaseMenu(
     id: Int,
     private var options: Array<Array<String>>,
     var option: Int,
-    callback: (Player, Array<String>, Child) -> Unit
+    callback: (Player, Child) -> Unit
 ) : Child(title, message, id, callback) {
     override fun show() {
         Call.menu(this.id, this.title, this.message, this.options)

--- a/src/main/kotlin/net/ddns/mindustry/segment/ui/menu/MenuHandler.kt
+++ b/src/main/kotlin/net/ddns/mindustry/segment/ui/menu/MenuHandler.kt
@@ -17,7 +17,7 @@ class MenuHandler : UIHandler<BaseMenu>() {
         title: String,
         message: String,
         options: Array<Array<String>>,
-        callback: (Player, Array<String>, Child) -> Unit
+        callback: (Player, Child) -> Unit
     ): BaseMenu {
         val id = generateID()
         val menu = BaseMenu(

--- a/src/main/kotlin/net/ddns/mindustry/segment/ui/textInput/BaseTextInput.kt
+++ b/src/main/kotlin/net/ddns/mindustry/segment/ui/textInput/BaseTextInput.kt
@@ -12,7 +12,7 @@ class BaseTextInput(
     override val title: String,
     override val message: String,
     override val id: Int,
-    override val callback: (player: Player, args: Array<String>, Child) -> Unit,
+    override val callback: (player: Player, Child) -> Unit,
 
     var text: String?,
 

--- a/src/main/kotlin/net/ddns/mindustry/segment/ui/textInput/TextInput.kt
+++ b/src/main/kotlin/net/ddns/mindustry/segment/ui/textInput/TextInput.kt
@@ -5,7 +5,7 @@ import net.ddns.mindustry.segment.ui.Child
 
 class TextInput(
     private val player: Player, title: String, message: String,
-    callback: (player: Player, args: Array<String>, Child) -> Unit, inputHandler: TextInputHandler,
+    callback: (player: Player, Child) -> Unit, inputHandler: TextInputHandler,
     charCount: Int = 1024, default: String = "", numeric: Boolean = false, args: Array<String> = arrayOf()) {
 
     private var textInput: BaseTextInput =

--- a/src/main/kotlin/net/ddns/mindustry/segment/ui/textInput/TextInputHandler.kt
+++ b/src/main/kotlin/net/ddns/mindustry/segment/ui/textInput/TextInputHandler.kt
@@ -19,7 +19,7 @@ class TextInputHandler : UIHandler<BaseTextInput>() {
     /**
      * Adds a text input for a given player.
      */
-    fun addTextInput(title: String, message: String, callback: (player: Player, args: Array<String>, Child) -> Unit,
+    fun addTextInput(title: String, message: String, callback: (player: Player, Child) -> Unit,
                      charCount: Int = 1024, default: String = "", numeric: Boolean = false
     ): BaseTextInput {
         val id = generateID()

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -3,5 +3,5 @@
   "author": "net.ddns.mindustry",
   "main": "net.ddns.mindustry.segment.Main",
   "description": "A framework that abstracts text inputs.",
-  "version": "0.2.0"
+  "version": "0.2.1"
 }


### PR DESCRIPTION
The args parameter was required for the callback, even though it's no longer necessary. 